### PR TITLE
Add examples for a ROS2 Topic and Service based communicaton from within CLIPS

### DIFF
--- a/cx_bringup/params/clips_executive.yaml
+++ b/cx_bringup/params/clips_executive.yaml
@@ -59,6 +59,9 @@ clips_executive:
             - name: clips_pddl_parser
             - name: skill_execution
             - name: clips_protobuf
+            - name: ros_topic_publisher
+            - name: ros_topic_subscriber
+            - name: ros_service_requester
           stage-3:
             - name: domain
               file: simple-agent/domain.clp
@@ -73,7 +76,9 @@ clips_executive:
                 - simple-agent/print-action.clp
                 - skills-actions.clp
             - name: refbox-comm
-              file: simple-agent/refbox-comm-init.clp
+              files:
+                - simple-agent/refbox-comm-init.clp
+                - simple-agent/ros-comm-init.clp
           # Map plan actions to skill strings.
         action-mapping:
           gowait: skill{}

--- a/cx_bringup/params/cx_params.yaml
+++ b/cx_bringup/params/cx_params.yaml
@@ -1,7 +1,7 @@
 
 clips_features_manager:
   ros__parameters:
-    clips_features: ["clips_pddl_parser", "skill_execution", "clips_protobuf"]
+    clips_features: ["clips_pddl_parser", "skill_execution", "clips_protobuf",  "ros_topic_publisher", "ros_topic_subscriber", "ros_service_requester"]
 
     mock_feature:
       plugin: "cx::MockFeature"
@@ -11,6 +11,12 @@ clips_features_manager:
       plugin: "cx::ClipsPddlParserFeature"
     skill_execution:
       plugin: "cx::SkillExecutionFeature"
+    ros_topic_publisher:
+      plugin: "cx::RosTopicPublisherFeature"
+    ros_topic_subscriber:
+      plugin: "cx::RosTopicSubscriberFeature"
+    ros_service_requester:
+      plugin: "cx::RosServiceRequesterFeature"
     clips_protobuf:
       plugin: "cx::ClipsProtobufFeature"
       feature_parameters: ["protobuf-path"]

--- a/cx_clips_executive/src/cx_clips_executive/clips/simple-agent/ros-comm-init.clp
+++ b/cx_clips_executive/src/cx_clips_executive/clips/simple-agent/ros-comm-init.clp
@@ -1,0 +1,50 @@
+;---------------------------------------------------------------------------
+;  ros-comm-init.clp - Initialize ROS2 based communication
+;
+;  Created: Wed 22 Nov 2023 12:04:00 CET
+;  Copyright  2023 Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+;  Licensed under GPLv2+ license, cf. LICENSE file in the doc directory.
+;---------------------------------------------------------------------------
+
+; This program is free software; you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation; either version 2 of the License, or
+; (at your option) any later version.
+;
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU Library General Public License for more details.
+;
+; Read the full text in the LICENSE.GPL file in the doc directory.
+;
+
+(defrule ros-comm-subscribe
+    (executive-init)
+    =>
+    (ros-default-subscribe "test")
+)
+
+(defrule ros-comm-publish
+    (executive-init)
+    (ros-default-message (topic "test"))
+    =>
+    (ros-default-create-publisher "/test2")
+    (ros-default-create-message "/test2")
+    (ros-default-set-field-publish "/test2" "data" "TEST")
+    (ros-default-publish "/test2")
+)
+
+(defrule ros-comm-request
+    (ros-default-message (topic "test"))
+    =>
+    (ros-default-create-request "testservice")
+    (ros-default-set-field-request "testservice" "data" "TRUE")
+    (ros-default-request "testservice")
+)
+
+(defrule ros-comm-print-response
+    (ros-default-response (service "testservice") (success ?succ))
+    =>
+    (printout t ?succ crlf)
+)

--- a/cx_features/CMakeLists.txt
+++ b/cx_features/CMakeLists.txt
@@ -53,7 +53,6 @@ set(dependencies
 set(CX_FEATURES_SOURCES
   src/cx_features/redefine_warning_feature/RedefineWarningFeature.cpp
   src/cx_features/config_feature/ConfigFeature.cpp
-  src/cx_features/blackboard_feature/BlackboardFeature.cpp
   src/cx_features/ClipsFeaturesManager.cpp
 )
 
@@ -86,6 +85,22 @@ add_library(skill_execution_feature SHARED src/cx_features/skill_execution_featu
 ament_target_dependencies(skill_execution_feature ${dependencies})
 target_link_libraries(skill_execution_feature PkgConfig::CLIPSMM)
 
+add_library(ros_service_requester_feature SHARED src/cx_features/ros_communication_feature/RosServiceRequesterFeature.cpp)
+ament_target_dependencies(ros_service_requester_feature ${dependencies})
+target_link_libraries(ros_service_requester_feature PkgConfig::CLIPSMM)
+
+add_library(ros_topic_publisher_feature SHARED src/cx_features/ros_communication_feature/RosTopicPublisherFeature.cpp)
+ament_target_dependencies(ros_topic_publisher_feature ${dependencies})
+target_link_libraries(ros_topic_publisher_feature PkgConfig::CLIPSMM)
+
+add_library(ros_topic_subscriber_feature SHARED src/cx_features/ros_communication_feature/RosTopicSubscriberFeature.cpp)
+ament_target_dependencies(ros_topic_subscriber_feature ${dependencies})
+target_link_libraries(ros_topic_subscriber_feature PkgConfig::CLIPSMM)
+
+add_library(blackboard_feature SHARED src/cx_features/blackboard_feature/BlackboardFeature.cpp)
+ament_target_dependencies(blackboard_feature ${dependencies})
+target_link_libraries(blackboard_feature PkgConfig::CLIPSMM)
+
 # END OF PLUGINS REGISTRATION
 add_library(${PROJECT_NAME} SHARED ${CX_FEATURES_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
@@ -115,6 +130,10 @@ install(TARGETS
   mock_feature
   plansys2_feature
   skill_execution_feature
+  blackboard_feature
+  ros_service_requester_feature
+  ros_topic_subscriber_feature
+  ros_topic_publisher_feature
   clips_pddl_parser_feature
   clips_protobuf_feature
   ${PROJECT_NAME}

--- a/cx_features/features_plugin.xml
+++ b/cx_features/features_plugin.xml
@@ -19,6 +19,21 @@
       <description>Clips Feature providing pddl file parsing to the Clips Environment</description>
     </class>
   </library>
+  <library path="ros_topic_subscriber_feature">
+    <class type="cx::RosTopicSubscriberFeature" base_class_type="cx::ClipsFeature">
+      <description>Clips Feature enabling the subscription to ROS2 topics</description>
+    </class>
+  </library>
+  <library path="ros_topic_publisher_feature">
+    <class type="cx::RosTopicPublisherFeature" base_class_type="cx::ClipsFeature">
+      <description>Clips Feature enabling the publishing to ROS2 topics</description>
+    </class>
+  </library>
+  <library path="ros_service_requester_feature">
+    <class type="cx::RosServiceRequesterFeature" base_class_type="cx::ClipsFeature">
+      <description>Clips Feature enabling requests to ROS2 services</description>
+    </class>
+  </library>
   <library path="clips_protobuf_feature">
     <class type="cx::ClipsProtobufFeature" base_class_type="cx::ClipsFeature">
       <description>Clips Feature providing Protobuf-based communication</description>

--- a/cx_features/include/cx_features/RosServiceRequesterFeature.hpp
+++ b/cx_features/include/cx_features/RosServiceRequesterFeature.hpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+ *  RosServiceRequesterFeature.hpp
+ *
+ *  Created: November 13th, 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_
+#define CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cx_core/ClipsFeature.hpp"
+#include "cx_utils/LockSharedPtr.hpp"
+#include "cx_utils/NodeThread.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+
+namespace cx {
+
+class RosServiceRequesterFeature : public ClipsFeature, public rclcpp::Node {
+public:
+  RosServiceRequesterFeature();
+  ~RosServiceRequesterFeature();
+
+  void initialise(const std::string &feature_name) override;
+
+  bool clips_context_init(const std::string &env_name,
+                          LockSharedPtr<CLIPS::Environment> &clips) override;
+  bool clips_context_destroyed(const std::string &env_name) override;
+
+  std::string getFeatureName() const;
+
+private:
+  std::map<std::string, LockSharedPtr<CLIPS::Environment>> envs_;
+  std::thread spin_thread_;
+  std::string msg_name_ = "default";
+  std::map<
+      std::string,
+      std::map<std::string, rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr>>
+      request_clients_;
+  std::map<
+      std::string,
+      std::map<std::string, std::shared_ptr<std_srvs::srv::SetBool::Request>>>
+      requests_;
+  void create_request(const std::string &env_name,
+                      const std::string &service_name);
+
+  void set_field_request(const std::string &env_name,
+                         const std::string &service_name,
+                         const std::string &field_name, CLIPS::Value value);
+
+  void set_array_request(const std::string &env_name,
+                         const std::string &service_name,
+                         const std::string &field_name, CLIPS::Values values);
+
+  void request_from_node(const std::string &env_name,
+                         const std::string &service_name);
+
+  void service_callback(
+      rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture response,
+      std::string service_name, std::string env_name);
+};
+} // namespace cx
+#endif // !CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_

--- a/cx_features/include/cx_features/RosTopicPublisherFeature.hpp
+++ b/cx_features/include/cx_features/RosTopicPublisherFeature.hpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *  RosTopicPublisherFeature.hpp
+ *
+ *  Created: November 13th, 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_
+#define CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cx_core/ClipsFeature.hpp"
+#include "cx_utils/LockSharedPtr.hpp"
+#include "cx_utils/NodeThread.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace cx {
+
+class RosTopicPublisherFeature : public ClipsFeature, public rclcpp::Node {
+public:
+  RosTopicPublisherFeature();
+  ~RosTopicPublisherFeature();
+
+  void initialise(const std::string &feature_name) override;
+
+  bool clips_context_init(const std::string &env_name,
+                          LockSharedPtr<CLIPS::Environment> &clips) override;
+  bool clips_context_destroyed(const std::string &env_name) override;
+
+  std::string getFeatureName() const;
+
+private:
+  std::string msg_name_ = "default";
+  std::map<std::string, LockSharedPtr<CLIPS::Environment>> envs_;
+  std::thread spin_thread_;
+  std::map<std::string,
+           std::map<std::string,
+                    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr>>
+      publishers_;
+  std::map<std::string, std::map<std::string, std_msgs::msg::String>> messages_;
+
+  void create_message(const std::string &env_name, const std::string &topic);
+
+  void set_field_publish(const std::string &env_name, const std::string &topic,
+                         const std::string &field, CLIPS::Value value);
+
+  void set_array_publish(const std::string &env_name, const std::string &topic,
+                         const std::string &field, CLIPS::Values values);
+
+  void publish_to_topic(const std::string &env_name,
+                        const std::string &topic_name);
+
+  void creater_publisher(const std::string &env_name,
+                         const std::string &topic_name);
+};
+
+} // namespace cx
+#endif // !CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_

--- a/cx_features/include/cx_features/RosTopicSubscriberFeature.hpp
+++ b/cx_features/include/cx_features/RosTopicSubscriberFeature.hpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *  RosTopicSubscriberFeature.hpp
+ *
+ *  Created: November 13th, 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_
+#define CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cx_core/ClipsFeature.hpp"
+#include "cx_utils/LockSharedPtr.hpp"
+#include "cx_utils/NodeThread.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace cx {
+
+class RosTopicSubscriberFeature : public ClipsFeature, public rclcpp::Node {
+public:
+  RosTopicSubscriberFeature();
+  ~RosTopicSubscriberFeature();
+
+  void initialise(const std::string &feature_name) override;
+
+  bool clips_context_init(const std::string &env_name,
+                          LockSharedPtr<CLIPS::Environment> &clips) override;
+  bool clips_context_destroyed(const std::string &env_name) override;
+
+  std::string getFeatureName() const;
+
+private:
+  std::map<std::string, LockSharedPtr<CLIPS::Environment>> envs_;
+  std::thread spin_thread_;
+  std::string msg_name_ = "default";
+  std::map<std::string,
+           std::map<std::string,
+                    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr>>
+      subscriptions_;
+
+  void subscribe_to_topic(const std::string &env_name,
+                          const std::string &topic_name);
+
+  void unsubscribe_from_topic(const std::string &env_name,
+                              const std::string &topic_name);
+
+  void topic_callback(const std_msgs::msg::String::SharedPtr msg,
+                      std::string topic_name, std::string env_name);
+};
+
+} // namespace cx
+#endif // !CX_FEATURES__CLIPSPROTOBUFFEATURE_HPP_

--- a/cx_features/src/cx_features/ClipsFeaturesManager.cpp
+++ b/cx_features/src/cx_features/ClipsFeaturesManager.cpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <utility>
 
-#include "cx_features/BlackboardFeature.hpp"
 #include "cx_features/ClipsFeaturesManager.hpp"
 #include "cx_features/MockFeature.hpp"
 #include "cx_features/RedefineWarningFeature.hpp"
@@ -317,12 +316,7 @@ void ClipsFeaturesManager::addGeneralFeatures() {
   configFeature->initialise("config_feature");
   RCLCPP_INFO(get_logger(), "Created feature config_feature");
 
-  // auto blackboardFeature = std::make_shared<cx::BlackboardFeature>();
-  // blackboardFeature->initialise("blackboard_feature");
-  // RCLCPP_INFO(get_logger(), "Created feature blackboard_feature");
-
   features_.insert({"redefine_warning_feature", redefineWarningFeature});
   features_.insert({"config_feature", configFeature});
-  // features_.insert({"blackboard_feature", blackboardFeature});
 }
 } // namespace cx

--- a/cx_features/src/cx_features/ros_communication_feature/RosServiceRequesterFeature.cpp
+++ b/cx_features/src/cx_features/ros_communication_feature/RosServiceRequesterFeature.cpp
@@ -1,0 +1,170 @@
+/***************************************************************************
+ *  RosTopicServiceRequesterFeature.cpp
+ *
+ *  Created: November 13th, 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cx_core/ClipsFeature.hpp"
+#include "cx_features/RosServiceRequesterFeature.hpp"
+#include "cx_utils/LockSharedPtr.hpp"
+
+// To export as plugin
+#include "pluginlib/class_list_macros.hpp"
+
+using std::placeholders::_1;
+
+namespace cx {
+
+RosServiceRequesterFeature::RosServiceRequesterFeature()
+    : Node("ros_topic_feature_node") {}
+RosServiceRequesterFeature::~RosServiceRequesterFeature() {}
+
+std::string RosServiceRequesterFeature::getFeatureName() const {
+  return clips_feature_name;
+}
+
+void RosServiceRequesterFeature::initialise(const std::string &feature_name) {
+  clips_feature_name = feature_name;
+
+  spin_thread_ =
+      std::thread([this]() { rclcpp::spin(this->get_node_base_interface()); });
+}
+
+bool RosServiceRequesterFeature::clips_context_init(
+    const std::string &env_name, LockSharedPtr<CLIPS::Environment> &clips) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Initialising context for feature %s",
+              clips_feature_name.c_str());
+
+  envs_[env_name] = clips;
+
+  // add base implementations for ros communication
+  // all of these need to be implemented given the corresponding types
+  clips->add_function(
+      "ros-" + msg_name_ + "-create-request",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosServiceRequesterFeature::create_request),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-set-field-request",
+      sigc::slot<void, std::string, std::string, CLIPS::Value>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosServiceRequesterFeature::set_field_request),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-set-array-request",
+      sigc::slot<void, std::string, std::string, CLIPS::Values>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosServiceRequesterFeature::set_array_request),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-request",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosServiceRequesterFeature::request_from_node),
+          env_name)));
+
+  // add base fact templates
+  clips->build("(deftemplate ros-" + msg_name_ + "-response\
+            (slot service (type STRING)) (slot success (type SYMBOL)))");
+
+  return true;
+}
+
+bool RosServiceRequesterFeature::clips_context_destroyed(
+    const std::string &env_name) {
+
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Destroying clips context!");
+  envs_.erase(env_name);
+
+  return true;
+}
+
+void RosServiceRequesterFeature::create_request(
+    const std::string &env_name, const std::string &service_name) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Creating request for service %s %s", service_name.c_str(),
+              env_name.c_str());
+
+  request_clients_[env_name][service_name] =
+      this->create_client<std_srvs::srv::SetBool>(service_name);
+  requests_[env_name][service_name] =
+      std::make_shared<std_srvs::srv::SetBool::Request>();
+}
+
+void RosServiceRequesterFeature::set_field_request(
+    const std::string &env_name, const std::string &service_name,
+    const std::string &field_name, CLIPS::Value value) {
+  if (field_name == "data") {
+    requests_[env_name][service_name]->data =
+        (value.as_string() == "TRUE") ? true : false;
+  }
+}
+
+void RosServiceRequesterFeature::set_array_request(
+    const std::string &env_name, const std::string &service_name,
+    const std::string &field_name, CLIPS::Values values) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Setting array %s for service %s %s not supported ",
+              field_name.c_str(), service_name.c_str(), env_name.c_str());
+  (void)values;
+}
+
+void RosServiceRequesterFeature::request_from_node(
+    const std::string &env_name, const std::string &service_name) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Requesting service %s %s", service_name.c_str(),
+              env_name.c_str());
+
+  auto response_callback =
+      [=](rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture response) {
+        service_callback(response, service_name, env_name);
+      };
+  request_clients_[env_name][service_name]->async_send_request(
+      requests_[env_name][service_name], response_callback);
+}
+
+void RosServiceRequesterFeature::service_callback(
+    rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture response,
+    std::string service_name, std::string env_name) {
+  cx::LockSharedPtr<CLIPS::Environment> &clips = envs_[env_name];
+  std::lock_guard<std::mutex> guard(*(clips.get_mutex_instance()));
+
+  // remove old responses facts
+  std::vector<CLIPS::Fact::pointer> facts = {};
+  CLIPS::Fact::pointer fact = envs_[env_name]->get_facts();
+  while (fact) {
+    if (fact->get_template()->name() == "ros-" + msg_name_ + "-response" &&
+        fact->slot_value("service")[0].as_string() == service_name) {
+      facts.push_back(fact);
+    }
+    fact = fact->next();
+  }
+  for (auto &fact : facts) {
+    fact->retract();
+  }
+  auto result = response.get();
+  // assert the newest responses
+  envs_[env_name]->assert_fact("(ros-" + msg_name_ + "-response (service \"" +
+                               service_name + "\") (success " +
+                               ((result->success) ? "TRUE ))" : "FALSE ))"));
+}
+
+} // namespace cx
+PLUGINLIB_EXPORT_CLASS(cx::RosServiceRequesterFeature, cx::ClipsFeature)

--- a/cx_features/src/cx_features/ros_communication_feature/RosTopicPublisherFeature.cpp
+++ b/cx_features/src/cx_features/ros_communication_feature/RosTopicPublisherFeature.cpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+ *  RosTopicPublisherFeature.cpp
+ *
+ *  Created: November 13th, 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cx_core/ClipsFeature.hpp"
+#include "cx_features/RosTopicPublisherFeature.hpp"
+#include "cx_utils/LockSharedPtr.hpp"
+
+// To export as plugin
+#include "pluginlib/class_list_macros.hpp"
+
+using std::placeholders::_1;
+
+namespace cx {
+
+RosTopicPublisherFeature::RosTopicPublisherFeature()
+    : Node("ros_topic_publisher_feature_node") {}
+RosTopicPublisherFeature::~RosTopicPublisherFeature() {}
+
+std::string RosTopicPublisherFeature::getFeatureName() const {
+  return clips_feature_name;
+}
+
+void RosTopicPublisherFeature::initialise(const std::string &feature_name) {
+  clips_feature_name = feature_name;
+
+  spin_thread_ =
+      std::thread([this]() { rclcpp::spin(this->get_node_base_interface()); });
+}
+
+bool RosTopicPublisherFeature::clips_context_destroyed(
+    const std::string &env_name) {
+
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Destroying clips context!");
+  envs_.erase(env_name);
+
+  return true;
+}
+
+bool RosTopicPublisherFeature::clips_context_init(
+    const std::string &env_name, LockSharedPtr<CLIPS::Environment> &clips) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Initialising context for feature %s",
+              clips_feature_name.c_str());
+
+  envs_[env_name] = clips;
+
+  clips->add_function(
+      "ros-" + msg_name_ + "-set-field-publish",
+      sigc::slot<void, std::string, std::string, CLIPS::Value>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosTopicPublisherFeature::set_field_publish),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-set-array-publish",
+      sigc::slot<void, std::string, std::string, CLIPS::Values>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosTopicPublisherFeature::set_array_publish),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-create-message",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosTopicPublisherFeature::create_message),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-create-publisher",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosTopicPublisherFeature::creater_publisher),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-publish",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosTopicPublisherFeature::publish_to_topic),
+          env_name)));
+
+  return true;
+}
+
+void RosTopicPublisherFeature::create_message(const std::string &env_name,
+                                              const std::string &topic) {
+  messages_[env_name][topic] = std_msgs::msg::String();
+}
+
+void RosTopicPublisherFeature::set_field_publish(const std::string &env_name,
+                                                 const std::string &topic,
+                                                 const std::string &field,
+                                                 CLIPS::Value value) {
+  if (field == "data") {
+    messages_[env_name][topic].data = value.as_string();
+  }
+}
+
+void RosTopicPublisherFeature::set_array_publish(const std::string &env_name,
+                                                 const std::string &topic,
+                                                 const std::string &field,
+                                                 CLIPS::Values values) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Setting array %s for service %s %s not supported ",
+              field.c_str(), topic.c_str(), env_name.c_str());
+  (void)values;
+}
+
+void RosTopicPublisherFeature::publish_to_topic(const std::string &env_name,
+                                                const std::string &topic_name) {
+  publishers_[env_name][topic_name]->publish(messages_[env_name][topic_name]);
+}
+
+void RosTopicPublisherFeature::creater_publisher(
+    const std::string &env_name, const std::string &topic_name) {
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+  publishers_[env_name][topic_name] =
+      this->create_publisher<std_msgs::msg::String>(topic_name, 10);
+}
+
+} // namespace cx
+PLUGINLIB_EXPORT_CLASS(cx::RosTopicPublisherFeature, cx::ClipsFeature)

--- a/cx_features/src/cx_features/ros_communication_feature/RosTopicSubscriberFeature.cpp
+++ b/cx_features/src/cx_features/ros_communication_feature/RosTopicSubscriberFeature.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+ *  RosTopicSubscriberFeature.cpp
+ *
+ *  Created: November 13th, 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "cx_core/ClipsFeature.hpp"
+#include "cx_features/RosTopicSubscriberFeature.hpp"
+#include "cx_utils/LockSharedPtr.hpp"
+
+// To export as plugin
+#include "pluginlib/class_list_macros.hpp"
+
+using std::placeholders::_1;
+
+namespace cx {
+
+RosTopicSubscriberFeature::RosTopicSubscriberFeature()
+    : Node("ros_topic_feature_node") {}
+RosTopicSubscriberFeature::~RosTopicSubscriberFeature() {}
+
+std::string RosTopicSubscriberFeature::getFeatureName() const {
+  return clips_feature_name;
+}
+
+void RosTopicSubscriberFeature::initialise(const std::string &feature_name) {
+  clips_feature_name = feature_name;
+
+  spin_thread_ =
+      std::thread([this]() { rclcpp::spin(this->get_node_base_interface()); });
+}
+
+bool RosTopicSubscriberFeature::clips_context_init(
+    const std::string &env_name, LockSharedPtr<CLIPS::Environment> &clips) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Initialising context for feature %s",
+              clips_feature_name.c_str());
+
+  envs_[env_name] = clips;
+
+  // add functions for subscribing and unsubscribing to the clips environment
+  clips->add_function(
+      "ros-" + msg_name_ + "-subscribe",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this, &RosTopicSubscriberFeature::subscribe_to_topic),
+          env_name)));
+  clips->add_function(
+      "ros-" + msg_name_ + "-unsubscribe",
+      sigc::slot<void, std::string>(sigc::bind<0>(
+          sigc::mem_fun(*this,
+                        &RosTopicSubscriberFeature::unsubscribe_from_topic),
+          env_name)));
+
+  // add fact templates
+  clips->build("(deftemplate ros-" + msg_name_ + "-subscribed \
+            (slot topic (type STRING)))");
+  clips->build("(deftemplate ros-" + msg_name_ + "-message \
+            (slot topic (type STRING)) (slot data (type STRING)))");
+
+  return true;
+}
+
+bool RosTopicSubscriberFeature::clips_context_destroyed(
+    const std::string &env_name) {
+
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+              "Destroying clips context!");
+  envs_.erase(env_name);
+
+  return true;
+}
+
+void RosTopicSubscriberFeature::subscribe_to_topic(
+    const std::string &env_name, const std::string &topic_name) {
+  RCLCPP_INFO(rclcpp::get_logger(clips_feature_name), "Subscribing to topic %s",
+              topic_name.c_str());
+
+  auto it = subscriptions_[env_name].find(topic_name);
+
+  if (it != subscriptions_[env_name].end()) {
+    RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+                "Already subscribed to topic %s", topic_name.c_str());
+  } else {
+    RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+                "Creating subscription to topic %s", topic_name.c_str());
+    subscriptions_[env_name][topic_name] =
+        this->create_subscription<std_msgs::msg::String>(
+            topic_name, 10, [=](const std_msgs::msg::String::SharedPtr msg) {
+              topic_callback(msg, topic_name, env_name);
+            });
+    envs_[env_name]->assert_fact("(ros-" + msg_name_ + "-subscribed (topic \"" +
+                                 topic_name + "\"))");
+  }
+}
+
+void RosTopicSubscriberFeature::unsubscribe_from_topic(
+    const std::string &env_name, const std::string &topic_name) {
+
+  auto it = subscriptions_[env_name].find(topic_name);
+
+  if (it != subscriptions_[env_name].end()) {
+    RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
+                "Unsubscribing from topic %s", topic_name.c_str());
+    subscriptions_[env_name].erase(topic_name);
+
+    // remove old message facts
+    std::vector<CLIPS::Fact::pointer> facts = {};
+    CLIPS::Fact::pointer fact = envs_[env_name]->get_facts();
+    while (fact) {
+      if ((fact->get_template()->name() == "ros-" + msg_name_ + "-message" &&
+           fact->slot_value("topic")[0].as_string() == topic_name) ||
+          fact->get_template()->name() == "ros-" + msg_name_ + "-subscribed") {
+        facts.push_back(fact);
+      }
+      fact = fact->next();
+    }
+    for (auto &fact : facts) {
+      fact->retract();
+    }
+  }
+}
+
+void RosTopicSubscriberFeature::topic_callback(
+    const std_msgs::msg::String::SharedPtr msg, std::string topic_name,
+    std::string env_name) {
+  cx::LockSharedPtr<CLIPS::Environment> &clips = envs_[env_name];
+  std::lock_guard<std::mutex> guard(*(clips.get_mutex_instance()));
+
+  // remove old message facts
+  std::vector<CLIPS::Fact::pointer> facts = {};
+  CLIPS::Fact::pointer fact = envs_[env_name]->get_facts();
+  while (fact) {
+    if (fact->get_template()->name() == "ros-" + msg_name_ + "-message" &&
+        fact->slot_value("topic")[0].as_string() == topic_name) {
+      facts.push_back(fact);
+    }
+    fact = fact->next();
+  }
+  for (auto &fact : facts) {
+    fact->retract();
+  }
+
+  // assert the newest message
+  envs_[env_name]->assert_fact("(ros-" + msg_name_ + "-message (topic \"" +
+                               topic_name + "\") (data \"" + msg->data +
+                               "\"))");
+}
+
+} // namespace cx
+PLUGINLIB_EXPORT_CLASS(cx::RosTopicSubscriberFeature, cx::ClipsFeature)

--- a/cx_msgs/CMakeLists.txt
+++ b/cx_msgs/CMakeLists.txt
@@ -5,6 +5,7 @@ project(cx_msgs)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(action_msgs REQUIRED)
 
@@ -13,7 +14,7 @@ set(MSGS
   "msg/ClipsFeature.msg"
   "msg/ClipsContext.msg"
   "msg/PddlGenInterface.msg"
-  "msg/PddlGenerateMessage.msg" 
+  "msg/PddlGenerateMessage.msg"
   "msg/PddlGenInterfaceMessages.msg"
   "msg/SkillExecutionerInformation.msg"
   "msg/SkillExecution.msg"
@@ -33,12 +34,12 @@ set(SERVICES
 # set(ACTIONS
 
 # )
-
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${MSGS}
   ${SERVICES}
+
   # ${actions}
-  DEPENDENCIES std_msgs builtin_interfaces action_msgs
+  DEPENDENCIES std_msgs std_srvs builtin_interfaces action_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)


### PR DESCRIPTION
Add example implementations of a Topic Publisher, a Topic Subscriber, and a Service Requester that can be controlled from within a CLIPS environment. 