### PR TITLE
protobuf path fix

### DIFF
--- a/cx_bringup/params/clips_features_manager.yaml
+++ b/cx_bringup/params/clips_features_manager.yaml
@@ -20,6 +20,6 @@ clips_features_manager:
         plugin: "cx::ClipsProtobufFeature"
         feature_parameters: ["protobuf_path"]
         protobuf_path:
-          # This path assumes relativeness to the workspace
-          value: "src/ros2-clips-executive/cx_bringup/proto"
+          # This path assumes relativeness to agent_dir
+          value: "proto"
           type: "string"

--- a/cx_features/src/cx_features/ClipsFeaturesManager.cpp
+++ b/cx_features/src/cx_features/ClipsFeaturesManager.cpp
@@ -92,6 +92,8 @@ ClipsFeaturesManager::on_configure(const rclcpp_lifecycle::State &state) {
 
         // declare the parameters define in the list for each feature
         std::map<std::string, rclcpp::Parameter> feature_param_map{};
+        feature_param_map["agent_dir"] =  get_parameter("agent_dir");
+
         declare_parameter("clips_features." + feat_name + ".feature_parameters",
                           std::vector<std::string>());
         std::vector<std::string> feature_parameters =

--- a/cx_features/src/cx_features/clips_protobuf_feature/ClipsProtobufFeature.cpp
+++ b/cx_features/src/cx_features/clips_protobuf_feature/ClipsProtobufFeature.cpp
@@ -51,10 +51,10 @@ bool ClipsProtobufFeature::clips_context_init(
               clips_feature_name.c_str());
 
   envs_[env_name] = clips;
+  std::vector<std::string> path = {parameters["agent_dir"].as_string() + "/" + parameters["protobuf_path"].as_string()};
   RCLCPP_INFO(rclcpp::get_logger(clips_feature_name),
               "Loading protobuf files from: %s",
-              parameters["protobuf_path"].as_string().c_str());
-  std::vector<std::string> path = {parameters["protobuf_path"].as_string()};
+              path[0].c_str());
   protobuf_communicator =
       std::make_unique<protobuf_clips::ClipsProtobufCommunicator>(
           envs_[env_name].get_obj().get(),


### PR DESCRIPTION
This PR addresses the issue that protobuf paths cant be properly specified.
It utilizes the assumption that protobuf files are located in the agent_dir.