### PR TITLE
cx_clips: properly use double instead of float for clips time

### DIFF
--- a/cx_clips/include/cx_clips/CLIPSEnvManagerNode.h
+++ b/cx_clips/include/cx_clips/CLIPSEnvManagerNode.h
@@ -114,7 +114,7 @@ private:
   void guarded_load(const std::string &env_name, const std::string &filename);
   CLIPS::Value clips_request_feature(const std::string &env_name,
                                      const std::string &feature_name);
-  float clips_now();
+  double clips_now();
   CLIPS::Values clips_now_systime();
 
   // Function for service clients

--- a/cx_clips/src/cx_clips/CLIPSEnvManagerNode.cpp
+++ b/cx_clips/src/cx_clips/CLIPSEnvManagerNode.cpp
@@ -567,7 +567,7 @@ void CLIPSEnvManagerNode::guarded_load(const std::string &env_name,
 void CLIPSEnvManagerNode::add_functions(const std::string &env_name) {
   getEnvironmentByName(env_name)->add_function(
       "now",
-      sigc::slot<float>(sigc::mem_fun(*this, &CLIPSEnvManagerNode::clips_now)));
+      sigc::slot<double>(sigc::mem_fun(*this, &CLIPSEnvManagerNode::clips_now)));
   getEnvironmentByName(env_name)->add_function(
       "now-systime", sigc::slot<CLIPS::Values>(sigc::mem_fun(
                          *this, &CLIPSEnvManagerNode::clips_now_systime)));
@@ -629,7 +629,7 @@ void CLIPSEnvManagerNode::call_feature_context_destroy(
   // }
 }
 
-float CLIPSEnvManagerNode::clips_now() { return get_clock()->now().seconds(); }
+double CLIPSEnvManagerNode::clips_now() { return get_clock()->now().seconds(); }
 
 CLIPS::Values CLIPSEnvManagerNode::clips_now_systime() {
   CLIPS::Values rv;


### PR DESCRIPTION
the ROS 2 time is double, by using float we actually lose significant precision and it becomes practically unusable.