### PR TITLE
Force focus on MAIN when loading file

### DIFF
--- a/cx_plugins/executive_plugin/clips/time.clp
+++ b/cx_plugins/executive_plugin/clips/time.clp
@@ -12,6 +12,7 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+(defmodule MAIN (export deftemplate time))
 (defglobal
   ?*PRIORITY-TIME-RETRACT*    = -10000
 )

--- a/cx_plugins/file_load_plugin/src/file_load_plugin.cpp
+++ b/cx_plugins/file_load_plugin/src/file_load_plugin.cpp
@@ -70,6 +70,8 @@ bool FileLoadPlugin::clips_env_init(LockSharedPtr<clips::Environment> &env) {
               context->env_name_.c_str());
   for (const auto &f : init_files_) {
 
+    clips::Defmodule *main_module = clips::FindDefmodule(env.get_obj().get(), "MAIN");
+    clips::Focus(main_module);
     if (clips::EE_NO_ERROR != clips::Eval(env.get_obj().get(),
                                           std::format("(load* {})", f).c_str(),
                                           NULL)) {


### PR DESCRIPTION
If files declare a module, the focus is switched to this module. That means that rules, functions, etc. of subsequently loaded files are also loaded into that module. Therefore we switch the focus in the file load plugin to MAIN before loading a new file to prevent this unwanted side effect.